### PR TITLE
ES-2724: Adding feature to exclude resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gcp-nuke*
+config.json

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NAME:
    gcp-nuke - The GCP project cleanup tool with added radiation
 
 USAGE:
-   e.g. gcp-nuke --project test-nuke-123456 --dryrun
+   e.g. gcp-nuke --project test-nuke-262510 --dryrun
 
 VERSION:
    v0.1.0
@@ -35,15 +35,16 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --project value   GCP project id to nuke (required)
-   --dryrun          Perform a dryrun instead (default: false)
-   --timeout value   Timeout for removal of a single resource in seconds (default: 400)
-   --polltime value  Time for polling resource deletion status in seconds (default: 10)
-   --help, -h        show help (default: false)
-   --version, -v     print the version (default: false)
+   --project value                       GCP project id to nuke (required)
+   --dryrun                              Perform a dryrun instead (default: false)
+   --timeout value                       Timeout for removal of a single resource in seconds (default: 400)
+   --polltime value                      Time for polling resource deletion status in seconds (default: 10)
+   --exclusionsconfig value, --ec value  Path to exclusions config file [$EXCLUSIONS_CONFIG]
+   --help, -h                            show help
+   --version, -v                         print the version
 ```
 
-Example dryrun
+### Example dryrun
 
 ```
 ./gcp-nuke --project test-nuke-123456 --dryrun
@@ -67,6 +68,28 @@ Example dryrun
 2019/12/23 13:53:32 [Dryrun] [Skip] Resource type ComputeDisks has nothing to destroy [project: test-nuke-123456]
 2019/12/23 13:53:33 [Dryrun] Resource type ComputeInstanceGroupsZone with resources [instance-group-1] would be destroyed [project: test-nuke-123456]
 2019/12/23 13:53:33 -- Deletion complete for project test-nuke-123456 (dry-run: true) --
+```
+
+### Example config file
+```json
+{
+  "bigquery": [],
+  "compute_disk": [],
+  "compute_firewall": [],
+  "compute_instance_groups_region": [],
+  "compute_instance_groups_zone": [],
+  "compute_instance": [], 
+  "compute_network_peering": [],
+  "compute_region_autoscaler": [],
+  "compute_router": [],
+  "compute_subnetwork": [],
+  "compute_vpn_gateway": [],
+  "compute_vpn_tunnel": [],
+  "compute_zone_autoscaler": [],
+  "container_gke_cluster": [],
+  "google_compute_network": [],
+  "iam_service_account": []
+}
 ```
 
 ## Roadmap

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -38,7 +38,7 @@ func Command() {
 				Usage: "Time for polling resource deletion status in seconds",
 			},
 			&cli.StringFlag{
-				Name:    "ExclusionsConfig, ec",
+				Name:    "exclusionsconfig, ec",
 				Usage:   "Path to exclusions config file",
 				EnvVars: []string{"EXCLUSIONS_CONFIG"},
 				Aliases: []string{"ec"},
@@ -57,22 +57,21 @@ func Command() {
 				Regions:  gcp.GetRegions(gcp.Ctx, c.String("project")),
 			}
 
-			if c.String("ExclusionsConfig") != "" {
+			if c.String("exclusionsconfig") != "" {
 				// Read exclusions config file and marshall into Config.Exclusions struct
-				var exclusions config.Exclusions
 
-				b, err := os.ReadFile(c.String("ExclusionsConfig"))
+				b, err := os.ReadFile(c.String("exclusionsconfig"))
 				if err != nil {
-					log.Printf("[Error] Exclusions config file not found at %v", c.String("ExclusionsConfig"))
+					log.Printf("[Error] Exclusions config file not found at %v", c.String("exclusionsconfig"))
 					return err
 				}
 
-				err = json.Unmarshal(b, &exclusions)
+				err = json.Unmarshal(b, &config.Exclusions)
 				if err != nil {
 					log.Printf("[Error] Exclusions config file could not be parsed")
 				}
 
-				config.Exclusions = exclusions
+				log.Printf("Loaded exclusions config: %+v", config.Exclusions)
 			}
 
 			log.Printf("[Info] Timeout %v seconds. Polltime %v seconds. Dry run: %v", config.Timeout, config.PollTime, config.DryRun)

--- a/gcp/bigquery_dataset.go
+++ b/gcp/bigquery_dataset.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"sync"
 
-	"golang.org/x/exp/slices"
 	bq "cloud.google.com/go/bigquery"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/bigquery/v2"
@@ -86,8 +86,9 @@ func (c *BigQueryDataset) Remove() error {
 		datasetID := value.(string)
 
 		// Check if a resource is exclued from deletion
-    if slices.Contains(c.base.config.Exclusions.BigQuery, datasetID) {
-   		// This datasetID is excluded from deletion, returning
+		if slices.Contains(c.base.config.Exclusions.BigQuery, datasetID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", datasetID, c.Name())
+			// This datasetID is excluded from deletion, returning
 			return false
 		}
 

--- a/gcp/compute_disks.go
+++ b/gcp/compute_disks.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -91,12 +91,13 @@ func (c *ComputeDisks) Remove() error {
 
 	c.resourceMap.Range(func(key, value interface{}) bool {
 		instanceID := key.(string)
-		zone := value.(DefaultResourceProperties).zone	
+		zone := value.(DefaultResourceProperties).zone
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeDisk, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ComputeDisk, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel instance deletion

--- a/gcp/compute_firewalls.go
+++ b/gcp/compute_firewalls.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
- 	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -86,9 +86,10 @@ func (c *ComputeFirewalls) Remove() error {
 	c.resourceMap.Range(func(key, value interface{}) bool {
 		firewallID := key.(string)
 
-  	// Check if resource is excluded
+		// Check if resource is excluded
 		if slices.Contains(c.base.config.Exclusions.ComputeFirewall, firewallID) {
-   		// Resource is excluded, skip deleting
+			log.Printf("[Info] Excluded resource: %v (%v)", firewallID, c.Name())
+			// Resource is excluded, skip deleting
 			return false
 		}
 

--- a/gcp/compute_instance_groups_region.go
+++ b/gcp/compute_instance_groups_region.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"	
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -91,11 +91,12 @@ func (c *ComputeInstanceGroupsRegion) Remove() error {
 		region := value.(DefaultResourceProperties).region
 
 		// Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeInstanceGroupsRegion, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		if slices.Contains(c.base.config.Exclusions.ComputeInstanceGroupsRegion, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
-		
+
 		// Parallel instance deletion
 		errs.Go(func() error {
 			deleteCall := c.serviceClient.RegionInstanceGroupManagers.Delete(c.base.config.Project, region, instanceID)

--- a/gcp/compute_instance_groups_zone.go
+++ b/gcp/compute_instance_groups_zone.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -105,10 +105,11 @@ func (c *ComputeInstanceGroupsZone) Remove() error {
 		instanceID := key.(string)
 		zone := value.(DefaultResourceProperties).zone
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeInstanceTemplate, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ComputeInstanceTemplate, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel instance deletion

--- a/gcp/compute_instance_templates.go
+++ b/gcp/compute_instance_templates.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
- 	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -87,10 +87,11 @@ func (c *ComputeInstanceTemplates) Remove() error {
 	c.resourceMap.Range(func(key, value interface{}) bool {
 		instanceID := key.(string)
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeInstanceTemplate, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ComputeInstanceTemplate, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel instance deletion

--- a/gcp/compute_instances.go
+++ b/gcp/compute_instances.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -102,11 +102,12 @@ func (c *ComputeInstances) Remove() error {
 		zone := value.(DefaultResourceProperties).zone
 
 		// Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeInstance, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		if slices.Contains(c.base.config.Exclusions.ComputeInstance, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
-		
+
 		// Parallel instance deletion
 		errs.Go(func() error {
 			getInstanceCall := c.serviceClient.Instances.Get(c.base.config.Project, zone, instanceID)

--- a/gcp/compute_network_peerings.go
+++ b/gcp/compute_network_peerings.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -90,11 +90,12 @@ func (c *ComputeNetworkPeerings) Remove() error {
 		networkID := value.(string)
 
 		// Check if a resource is exclued from deletion
-    if slices.Contains(c.base.config.Exclusions.ComputeNetworkPeering, networkPeeringID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		if slices.Contains(c.base.config.Exclusions.ComputeNetworkPeering, networkID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", networkID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
-		
+
 		// Parallel network deletion
 		errs.Go(func() error {
 

--- a/gcp/compute_region_autoscalers.go
+++ b/gcp/compute_region_autoscalers.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"sync"
 	"time"
- 
-	"golang.org/x/exp/slices"
+
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -89,10 +89,11 @@ func (c *ComputeRegionAutoScalers) Remove() error {
 		instanceID := key.(string)
 		region := value.(DefaultResourceProperties).region
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeRegionAutoscaler, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ComputeRegionAutoscaler, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel instance deletion

--- a/gcp/compute_routers.go
+++ b/gcp/compute_routers.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-  "golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -88,10 +88,11 @@ func (c *ComputeRouters) Remove() error {
 		routerID := key.(string)
 		region := value.(string)
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeRouter, routerID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ComputeRouter, routerID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", routerID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel router deletion

--- a/gcp/compute_subnetworks.go
+++ b/gcp/compute_subnetworks.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
- "golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -89,10 +89,11 @@ func (c *ComputeSubnetworks) Remove() error {
 		subnetworkID := key.(string)
 		region := value.(string)
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeSubNetwork, subnetworkID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ComputeSubNetwork, subnetworkID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", subnetworkID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel subnetwork deletion

--- a/gcp/compute_vpn_gateways.go
+++ b/gcp/compute_vpn_gateways.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
- 	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -87,10 +87,11 @@ func (c *ComputeVPNGateways) Remove() error {
 		gatewayID := key.(string)
 		region := value.(string)
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeVPNGateway, gatewayID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ComputeVPNGateway, gatewayID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", gatewayID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel gateway deletion

--- a/gcp/compute_vpn_tunnels.go
+++ b/gcp/compute_vpn_tunnels.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
- 	"golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -87,11 +87,12 @@ func (c *ComputeVPNTunnels) Remove() error {
 		region := value.(string)
 
 		// Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeVPNTunnel, tunnelID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		if slices.Contains(c.base.config.Exclusions.ComputeVPNTunnel, tunnelID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", tunnelID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
-		
+
 		// Parallel tunnel deletion
 		errs.Go(func() error {
 			deleteCall := c.serviceClient.VpnTunnels.Delete(c.base.config.Project, region, tunnelID)

--- a/gcp/compute_zone_autoscalers.go
+++ b/gcp/compute_zone_autoscalers.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-  "golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -90,11 +90,12 @@ func (c *ComputeZoneAutoScalers) Remove() error {
 		zone := value.(DefaultResourceProperties).zone
 
 		// Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ComputeZoneAutoscaler, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		if slices.Contains(c.base.config.Exclusions.ComputeZoneAutoscaler, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
-	
+
 		// Parallel instance deletion
 		errs.Go(func() error {
 			deleteCall := c.serviceClient.Autoscalers.Delete(c.base.config.Project, zone, instanceID)

--- a/gcp/container_gke_clusters.go
+++ b/gcp/container_gke_clusters.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-  "golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/container/v1"
@@ -90,10 +90,11 @@ func (c *ContainerGKEClusters) Remove() error {
 		instanceID := key.(string)
 		location := strings.Split(instanceID, "/")[3]
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.ContainerGKECluster, instanceID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is exclued from deletion
+		if slices.Contains(c.base.config.Exclusions.ContainerGKECluster, instanceID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", instanceID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel instance deletion

--- a/gcp/google_compute_networks.go
+++ b/gcp/google_compute_networks.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-  "golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/compute/v1"
@@ -84,10 +84,11 @@ func (c *ComputeNetworks) Remove() error {
 	c.resourceMap.Range(func(key, value interface{}) bool {
 		networkID := key.(string)
 
-    // Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.GoogleComputeNetwork, networkID) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		// Check if a resource is excluded from deletion
+		if slices.Contains(c.base.config.Exclusions.GoogleComputeNetwork, networkID) {
+			log.Printf("[Info] Excluded resource: %v (%v)", networkID, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel network deletion

--- a/gcp/iam_service_accounts.go
+++ b/gcp/iam_service_accounts.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"sync"
 
-  "golang.org/x/exp/slices"
 	"github.com/BESTSELLER/gcp-nuke/config"
 	"github.com/BESTSELLER/gcp-nuke/helpers"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/api/iam/v1"
@@ -82,9 +82,10 @@ func (c *IAMServiceAccount) Remove() error {
 		emailAddress := value.(string)
 
 		// Check if a resource is exclued from deletion
-  	if slices.Contains(c.base.config.Exclusions.IAMServiceAccount, emailAddress) {
-  		// This instanceID is excluded from deletion, returning
-  		return false
+		if slices.Contains(c.base.config.Exclusions.IAMServiceAccount, emailAddress) {
+			log.Printf("[Info] Excluded resource: %v (%v)", emailAddress, c.Name())
+			// This instanceID is excluded from deletion, returning
+			return false
 		}
 
 		// Parallel instance deletion

--- a/main.go
+++ b/main.go
@@ -5,3 +5,4 @@ import "github.com/BESTSELLER/gcp-nuke/cmd"
 func main() {
 	cmd.Command()
 }
+


### PR DESCRIPTION
# Changes
- Added the possibility of excluding resources so they don't get nuked. This is needed in ES-2724 because of the tests in non-peered Redis, which need VPCs and connections.